### PR TITLE
Add test case for handling _COPYING_ files

### DIFF
--- a/src/test/java/de/m3y/prometheus/exporter/fsimage/FsImageWatcherTest.java
+++ b/src/test/java/de/m3y/prometheus/exporter/fsimage/FsImageWatcherTest.java
@@ -41,6 +41,38 @@ public class FsImageWatcherTest {
         assertEquals(file_3, FsImageWatcher.findLatestFSImageFile(tempDirectory));
     }
 
+    @Test
+    public void testFindLatestFSImageFileWhileCopying() throws IOException {
+        File tempDirectory = Files.createTempDirectory("findLatestFSImageFile").toFile();
+        tempDirectory.deleteOnExit();
+
+        // Non-existent dir
+        try {
+            FsImageWatcher.findLatestFSImageFile(new File(tempDirectory, "non-existent"));
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException ex) {
+            // expected
+        }
+
+        // Empty dir
+        try {
+            FsImageWatcher.findLatestFSImageFile(tempDirectory);
+            fail("Expected IllegalStateException");
+        } catch (IllegalStateException ex) {
+            // expected
+        }
+
+        final File file_1 = createTmpFile(tempDirectory, "fsimage_0000000001650677390");
+        assertEquals(file_1, FsImageWatcher.findLatestFSImageFile(tempDirectory));
+
+        final File file_2 = createTmpFile(tempDirectory, "fsimage_0000000001650677391");
+        assertEquals(file_2, FsImageWatcher.findLatestFSImageFile(tempDirectory));
+
+        final File file_3 = createTmpFile(tempDirectory, "fsimage_1000000001650677392._COPYING_");
+        assertEquals(file_2, FsImageWatcher.findLatestFSImageFile(tempDirectory));
+        assertNotEquals(file_3, FsImageWatcher.findLatestFSImageFile(tempDirectory));
+    }
+
     private File createTmpFile(File tempDirectory, String fileName) throws IOException {
         final File newFile = new File(tempDirectory, fileName);
         assertTrue(newFile.createNewFile());


### PR DESCRIPTION
The test covers scenarios where:
- The directory contains a mix of complete fsimage files and one that is currently being copied.
- The FsImageWatcher should correctly ignore the '_COPYING_' file and return the latest complete fsimage file.